### PR TITLE
Reorder social icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                         <a href="https://twitter.com/adisakshya" title="Connect on Twitter" class="icon-button twitter" rel="noopener noreferrer"><i class="fab fa-twitter"></i><span></span></a>
                         <a href="https://github.com/adisakshya" title="Follow on GitHub" class="icon-button github" rel="noopener noreferrer"><i class="fab fa-github"></i><span></span></a>
                         <a href="/weblog/" title="The Blog of Adisakshya Chauhan" class="icon-button blog" rel="noopener noreferrer"><i class="fas fa-pen-nib"></i><span></span></a>
-                        <a href="mailto:adisakshya@oulook.com" title="Drop an email" class="icon-button google" rel="noopener noreferrer"><i class="fas fa-envelope"></i><span></span></a>
+                        <a href="mailto:adisakshya@outlook.com" title="Drop an email" class="icon-button google" rel="noopener noreferrer"><i class="fas fa-envelope"></i><span></span></a>
                         <a href="#open-modal" title="Open website in mobile devices" class="icon-button mobile" rel="noopener noreferrer"><i class="fa fa-mobile"></i><span></span></a>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -115,11 +115,11 @@
                     </p>
                     <!-- SOCIAL + LINKS -->
                     <div class="social-media-div">
-                        <a href="https://github.com/adisakshya" title="Follow on GitHub" class="icon-button github" rel="noopener noreferrer"><i class="fab fa-github"></i><span></span></a>
-                        <a href="https://twitter.com/adisakshya" title="Connect on Twitter" class="icon-button twitter" rel="noopener noreferrer"><i class="fab fa-twitter"></i><span></span></a>
-                        <a href="mailto:adisakshya@oulook.com" title="Drop an email" class="icon-button google" rel="noopener noreferrer"><i class="fas fa-envelope"></i><span></span></a>
                         <a href="https://www.linkedin.com/in/adisakshya" title="Connect on LinkedIn" class="icon-button linkedin" rel="noopener noreferrer"><i class="fab fa-linkedin-in"></i><span></span></a>
-						<a href="/weblog/" title="The Blog of Adisakshya Chauhan" class="icon-button blog" rel="noopener noreferrer"><i class="fas fa-pen-nib"></i><span></span></a>
+                        <a href="https://twitter.com/adisakshya" title="Connect on Twitter" class="icon-button twitter" rel="noopener noreferrer"><i class="fab fa-twitter"></i><span></span></a>
+                        <a href="https://github.com/adisakshya" title="Follow on GitHub" class="icon-button github" rel="noopener noreferrer"><i class="fab fa-github"></i><span></span></a>
+                        <a href="/weblog/" title="The Blog of Adisakshya Chauhan" class="icon-button blog" rel="noopener noreferrer"><i class="fas fa-pen-nib"></i><span></span></a>
+                        <a href="mailto:adisakshya@oulook.com" title="Drop an email" class="icon-button google" rel="noopener noreferrer"><i class="fas fa-envelope"></i><span></span></a>
                         <a href="#open-modal" title="Open website in mobile devices" class="icon-button mobile" rel="noopener noreferrer"><i class="fa fa-mobile"></i><span></span></a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- reorder the social media icons so that LinkedIn appears first followed by Twitter, GitHub, blog, email and mobile

## Testing
- `npm test` *(fails: could not find package.json)*
- `npx eslint .` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68615fd37d788321a2515dad351abd2f